### PR TITLE
Lk: changes toward new relic implementation

### DIFF
--- a/lib/java_buildpack/framework/new_relic_agent.rb
+++ b/lib/java_buildpack/framework/new_relic_agent.rb
@@ -73,7 +73,8 @@ module JavaBuildpack
       end
 
       def agent_enabled
-        ENV['agent_enabled']
+         enabled = ENV['new_relic_agent_enabled']
+         enabled.to_s == '' ? false : enabled
       end
 
       def logs_dir

--- a/lib/java_buildpack/framework/new_relic_agent.rb
+++ b/lib/java_buildpack/framework/new_relic_agent.rb
@@ -37,6 +37,7 @@ module JavaBuildpack
         .add_javaagent(@droplet.sandbox + jar_name)
         .add_system_property('newrelic.home', @droplet.sandbox)
         .add_system_property('newrelic.config.license_key', license_key)
+        .add_system_property('newrelic.config.agent_enabled', agent_enabled)
         .add_system_property('newrelic.config.app_name', "'#{application_name}'")
         .add_system_property('newrelic.config.log_file_path', logs_dir)
         .add_system_property('newrelic.config.log_level', "info")
@@ -69,6 +70,10 @@ module JavaBuildpack
 
       def license_key
         @application.services.find_service(FILTER)['credentials']['licenseKey']
+      end
+
+      def agent_enabled
+        ENV['agent_enabled']
       end
 
       def logs_dir

--- a/resources/new_relic_agent/newrelic.yml
+++ b/resources/new_relic_agent/newrelic.yml
@@ -19,7 +19,7 @@ common: &default_settings
   # Agent Enabled
   # Use this setting to force the agent to run or not run.
   # Default is true.
-  # agent_enabled: true
+  agent_enabled: ''
 
   # Set to true to enable support for auto app naming.
   # The name of each web app is detected automatically

--- a/spec/application_helper.rb
+++ b/spec/application_helper.rb
@@ -48,6 +48,8 @@ shared_context 'application_helper' do
 
   let(:vcap_application) { { 'application_name' => 'test-application-name' } }
 
+  let(:vcap_application) { { 'agent_enabled' => 'true' } }
+
   let(:vcap_services) do
     { 'test-service-n/a' => [{ 'name'        => 'test-service-name', 'label' => 'test-service-n/a',
                                'tags'        => ['test-service-tag'], 'plan' => 'test-plan',

--- a/spec/java_buildpack/framework/new_relic_agent_spec.rb
+++ b/spec/java_buildpack/framework/new_relic_agent_spec.rb
@@ -59,6 +59,7 @@ describe JavaBuildpack::Framework::NewRelicAgent do
       expect(java_opts).to include("-javaagent:$PWD/.java-buildpack/new_relic_agent/new_relic_agent-#{version}.jar")
       expect(java_opts).to include('-Dnewrelic.home=$PWD/.java-buildpack/new_relic_agent')
       expect(java_opts).to include('-Dnewrelic.config.license_key=test-license-key')
+      expect(java_opts).to include('-Dnewrelic.config.agent_enabled=true')
       expect(java_opts).to include("-Dnewrelic.config.app_name='test-application-name'")
       expect(java_opts).to include('-Dnewrelic.config.log_file_path=$PWD/.java-buildpack/new_relic_agent/logs')
     end


### PR DESCRIPTION
Enabling nimbus2 apps to set monitoring to on or off depending on the agent_enabled switch in their app manifest file. This option is required to set monitoring to the offline mode for the stage environment by default because of the costs involved