### PR TITLE
@pszals @leok80: Allow configuration of NewRelic using environment variables on Nimbus 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build/
 coverage
 doc
+*.sw*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Max: 10
 Metrics/LineLength:
-  Max: 120
+  Max: 160
 Metrics/MethodLength:
   Max: 17
 Metrics/ParameterLists:

--- a/lib/java_buildpack/buildpack.rb
+++ b/lib/java_buildpack/buildpack.rb
@@ -92,18 +92,17 @@ module JavaBuildpack
 
     private
 
-    def get_vcap_services
+    def vcap_services
       JSON(ENV['VCAP_SERVICES'] || '{}')
     end
 
-    def get_mongodb_credentials
-      get_vcap_services["mongodb-2.2"][0]["credentials"]
+    def mongodb_credentials
+      vcap_services['mongodb-2.2'][0]['credentials']
     end
 
-    def get_mongodb_url
-      get_mongodb_credentials["url"]
+    def mongodb_url
+      mongodb_credentials['url']
     end
-
 
     BUILDPACK_MESSAGE = '-----> Java Buildpack Version: %s'.freeze
 

--- a/lib/java_buildpack/framework/new_relic_agent.rb
+++ b/lib/java_buildpack/framework/new_relic_agent.rb
@@ -33,17 +33,17 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
-        @droplet.java_opts
-        .add_javaagent(@droplet.sandbox + jar_name)
-        .add_system_property('newrelic.home', @droplet.sandbox)
-        .add_system_property('newrelic.config.license_key', license_key)
-        .add_system_property('newrelic.config.app_name', "'#{application_name}'")
-        .add_system_property('newrelic.config.log_file_path', logs_dir)
-        .add_system_property('newrelic.config.log_level', "info")
+        @droplet.java_opts.add_javaagent(@droplet.sandbox + jar_name)
+        @droplet.java_opts.add_system_property('newrelic.config.license_key', license_key)
+        @droplet.java_opts.add_system_property('newrelic.home', @droplet.sandbox)
+        @droplet.java_opts.add_system_property('newrelic.config.agent_enabled', agent_enabled)
+        @droplet.java_opts.add_system_property('newrelic.config.app_name', "'#{application_name}'")
+        @droplet.java_opts.add_system_property('newrelic.config.log_file_path', logs_dir)
+        @droplet.java_opts.add_system_property('newrelic.config.log_level', 'info')
         @droplet.java_opts.add_system_property('newrelic.enable.java.8', 'true') if @droplet.java_home.version[1] == '8'
-        @droplet.java_opts.add_system_property('newrelic.config.proxy_host', '$WEB_PROXY_HOST') if !proxy_host.nil? and !proxy_host.empty?
-        @droplet.java_opts.add_system_property('newrelic.config.proxy_user', '$WEB_PROXY_USER') if !proxy_user.nil? and !proxy_user.empty?
-        @droplet.java_opts.add_system_property('newrelic.config.proxy_password', '$WEB_PROXY_PASS') if !proxy_password.nil? and !proxy_password.empty?
+        @droplet.java_opts.add_system_property('newrelic.config.proxy_host', '$WEB_PROXY_HOST') if !proxy_host.nil? && !proxy_host.empty?
+        @droplet.java_opts.add_system_property('newrelic.config.proxy_user', '$WEB_PROXY_USER') if !proxy_user.nil? && !proxy_user.empty?
+        @droplet.java_opts.add_system_property('newrelic.config.proxy_password', '$WEB_PROXY_PASS') if !proxy_password.nil? && !proxy_password.empty?
         @droplet.java_opts.add_system_property('newrelic.config.proxy_port', '$WEB_PROXY_PORT') if !proxy_port.nil?
       end
 
@@ -69,6 +69,10 @@ module JavaBuildpack
 
       def license_key
         @application.services.find_service(FILTER)['credentials']['licenseKey']
+      end
+
+      def agent_enabled
+        ENV['new_relic_agent_enabled'] == 'true' ? 'true' : 'false'
       end
 
       def logs_dir

--- a/resources/new_relic_agent/newrelic.yml
+++ b/resources/new_relic_agent/newrelic.yml
@@ -19,7 +19,7 @@ common: &default_settings
   # Agent Enabled
   # Use this setting to force the agent to run or not run.
   # Default is true.
-  # agent_enabled: true
+  agent_enabled: ''
 
   # Set to true to enable support for auto app naming.
   # The name of each web app is detected automatically

--- a/spec/application_helper.rb
+++ b/spec/application_helper.rb
@@ -26,8 +26,14 @@ shared_context 'application_helper' do
   previous_environment = ENV.to_hash
 
   let(:environment) do
-    { 'test-key'      => 'test-value', 'VCAP_APPLICATION' => vcap_application.to_yaml,
-      'VCAP_SERVICES' => vcap_services.to_yaml }
+    {
+      'test-key'                   => 'test-value',
+      'VCAP_APPLICATION'           => vcap_application.to_yaml,
+      'VCAP_SERVICES'              => vcap_services.to_yaml,
+      'new_relic_application_name' => 'test-application-name',
+      'new_relic_agent_enabled'    => 'true',
+      'application_name'           => 'test-application-name'
+    }
   end
 
   before do

--- a/spec/java_buildpack/framework/new_relic_agent_spec.rb
+++ b/spec/java_buildpack/framework/new_relic_agent_spec.rb
@@ -51,17 +51,38 @@ describe JavaBuildpack::Framework::NewRelicAgent do
       expect(sandbox + 'newrelic.yml').to exist
     end
 
-    it 'updates JAVA_OPTS' do
-      allow(services).to receive(:find_service).and_return('credentials' => { 'licenseKey' => 'test-license-key' })
+    context 'when options are present' do
+      it 'updates JAVA_OPTS' do
+        allow(services).to receive(:find_service).and_return('credentials' => { 'licenseKey' => 'test-license-key' })
 
-      component.release
+        component.release
 
-      expect(java_opts).to include("-javaagent:$PWD/.java-buildpack/new_relic_agent/new_relic_agent-#{version}.jar")
-      expect(java_opts).to include('-Dnewrelic.home=$PWD/.java-buildpack/new_relic_agent')
-      expect(java_opts).to include('-Dnewrelic.config.license_key=test-license-key')
-      expect(java_opts).to include('-Dnewrelic.config.agent_enabled=true')
-      expect(java_opts).to include("-Dnewrelic.config.app_name='test-application-name'")
-      expect(java_opts).to include('-Dnewrelic.config.log_file_path=$PWD/.java-buildpack/new_relic_agent/logs')
+        expect(java_opts).to include("-javaagent:$PWD/.java-buildpack/new_relic_agent/new_relic_agent-#{version}.jar")
+        expect(java_opts).to include('-Dnewrelic.home=$PWD/.java-buildpack/new_relic_agent')
+        expect(java_opts).to include('-Dnewrelic.config.license_key=test-license-key')
+        expect(java_opts).to include('-Dnewrelic.config.agent_enabled=true')
+        expect(java_opts).to include("-Dnewrelic.config.app_name='test-application-name'")
+        expect(java_opts).to include('-Dnewrelic.config.log_file_path=$PWD/.java-buildpack/new_relic_agent/logs')
+      end
+    end
+
+    context 'when options are set to false' do
+      it 'updates JAVA_OPTS' do
+        allow(services).to receive(:find_service).and_return('credentials' => { 'licenseKey' => 'test-license-key' })
+        options = { 'new_relic_agent_enabled' => 'false' }
+        ENV.update options
+        component.release
+        expect(java_opts).to include('-Dnewrelic.config.agent_enabled=false')
+      end
+    end
+
+    context 'when options are absent' do
+      it 'updates JAVA_OPTS' do
+        allow(services).to receive(:find_service).and_return('credentials' => { 'licenseKey' => 'test-license-key' })
+        ENV.delete('new_relic_agent_enabled')
+        component.release
+        expect(java_opts).to include('-Dnewrelic.config.agent_enabled=false')
+      end
     end
 
     it 'updates JAVA_OPTS on Java 8' do

--- a/spec/java_buildpack/framework/new_relic_agent_spec.rb
+++ b/spec/java_buildpack/framework/new_relic_agent_spec.rb
@@ -59,6 +59,7 @@ describe JavaBuildpack::Framework::NewRelicAgent do
       expect(java_opts).to include("-javaagent:$PWD/.java-buildpack/new_relic_agent/new_relic_agent-#{version}.jar")
       expect(java_opts).to include('-Dnewrelic.home=$PWD/.java-buildpack/new_relic_agent')
       expect(java_opts).to include('-Dnewrelic.config.license_key=test-license-key')
+      expect(java_opts).to include('-Dnewrelic.config.agent_enabled=true')
       expect(java_opts).to include("-Dnewrelic.config.app_name='test-application-name'")
       expect(java_opts).to include('-Dnewrelic.config.log_file_path=$PWD/.java-buildpack/new_relic_agent/logs')
     end


### PR DESCRIPTION
    - set monitoring to on or off depending on the agent_enabled switch in their app
      manifest file. This option is required to set monitoring to the offline mode
      for the stage environment by default because of the costs involved
    - default agent_enabled to false